### PR TITLE
add verbal-fluency task

### DIFF
--- a/baseline/client/css/jspsych-timed-writing.css
+++ b/baseline/client/css/jspsych-timed-writing.css
@@ -1,0 +1,10 @@
+#jspsych-timed-writing-textarea {
+    font-family: "Open Sans", "Arial", sans-serif;
+    font-size: 18px;
+    padding: 20px;
+    margin: 20px;
+    color: MidnightBlue;
+    border-color: LightSteelBlue;
+    background-color: AliceBlue;
+    outline-color: CornflowerBlue;
+}

--- a/baseline/client/css/jspsych-timed-writing.css
+++ b/baseline/client/css/jspsych-timed-writing.css
@@ -8,3 +8,7 @@
     background-color: AliceBlue;
     outline-color: CornflowerBlue;
 }
+
+#jspsych-timed-writing-timer {
+    color: Gray;
+}

--- a/baseline/client/js/jspsych-timed-writing.js
+++ b/baseline/client/js/jspsych-timed-writing.js
@@ -37,6 +37,7 @@ jsPsych.plugins["timed-writing"] = (() => {
             html += `<textarea id="jspsych-timed-writing-textarea" rows="${r}" cols="${c}"></textarea>`;
             display_element.innerHTML = html;
             document.querySelector("#jspsych-timed-writing-timer").hidden = !trial.show_timer;
+            document.querySelector("#jspsych-timed-writing-textarea").focus();
         }
         // start display timer to show remaining time
         {

--- a/baseline/client/js/jspsych-timed-writing.js
+++ b/baseline/client/js/jspsych-timed-writing.js
@@ -1,0 +1,65 @@
+jsPsych.plugins["timed-writing"] = (() => {
+    const plugin = {};
+
+    plugin.info = {
+        name: "timed-writing",
+        parameters: {
+            duration: {
+                type: jsPsych.plugins.parameterType.INT,
+                default: undefined,
+            },
+            stimulus: {
+                type: jsPsych.plugins.parameterType.HTML_STRING,
+                default: undefined,
+            },
+            textarea_rows: {
+                type: jsPsych.plugins.parameterType.INT,
+                default: undefined,
+            },
+            textarea_cols: {
+                type: jsPsych.plugins.parameterType.INT,
+                default: undefined,
+            },
+            show_timer: {
+                type: jsPsych.plugins.parameterType.BOOL,
+                default: true,
+            }
+        },
+    };
+
+    plugin.trial = (display_element, trial) => {
+        // build and show display HTML
+        {
+            let html = "";
+            html += `<div id="jspsych-timed-writing-timer"></div>`;
+            html += `<div id="jspsych-timed-writing-stimulus">${trial.stimulus}</div>`;
+            const [r, c] = [trial.textarea_rows, trial.textarea_cols];
+            html += `<textarea id="jspsych-timed-writing-textarea" rows="${r}" cols="${c}"></textarea>`;
+            display_element.innerHTML = html;
+            document.querySelector("#jspsych-timed-writing-timer").hidden = !trial.show_timer;
+        }
+        // start display timer to show remaining time
+        {
+            let clock_seconds = Math.floor(trial.duration / 1000) - 1;
+            (function update_clock() {
+                const clock = document.querySelector("#jspsych-timed-writing-timer");
+                if (clock !== null && clock_seconds >= 0) {
+                    clock.textContent = `${clock_seconds} s`;
+                    --clock_seconds;
+                    setTimeout(update_clock, 1000);
+                }
+            })();
+        }
+        // start logical timer to end trial
+        setTimeout(() => {
+            const data = {
+                stimulus: trial.stimulus,
+                response: document.querySelector("#jspsych-timed-writing-textarea").value,
+            };
+            display_element.innerHTML = "";
+            jsPsych.finishTrial(data);
+        }, trial.duration);
+    };
+
+    return plugin;
+})();

--- a/baseline/client/js/jspsych-timed-writing.js
+++ b/baseline/client/js/jspsych-timed-writing.js
@@ -31,10 +31,10 @@ jsPsych.plugins["timed-writing"] = (() => {
         // build and show display HTML
         {
             let html = "";
-            html += `<div id="jspsych-timed-writing-timer"></div>`;
             html += `<div id="jspsych-timed-writing-stimulus">${trial.stimulus}</div>`;
             const [r, c] = [trial.textarea_rows, trial.textarea_cols];
             html += `<textarea id="jspsych-timed-writing-textarea" rows="${r}" cols="${c}"></textarea>`;
+            html += `<div id="jspsych-timed-writing-timer"></div>`;
             display_element.innerHTML = html;
             document.querySelector("#jspsych-timed-writing-timer").hidden = !trial.show_timer;
             document.querySelector("#jspsych-timed-writing-textarea").focus();

--- a/baseline/client/verbal-fluency/frag/completion.html
+++ b/baseline/client/verbal-fluency/frag/completion.html
@@ -1,0 +1,2 @@
+Task complete. <br>
+<em>Press the space bar to finish.</em>

--- a/baseline/client/verbal-fluency/frag/instruction.html
+++ b/baseline/client/verbal-fluency/frag/instruction.html
@@ -1,0 +1,8 @@
+<h1>Instruction:</h1>
+Are you ready for the next challenge? <br>
+You will be asked to type as many words starting with one particular letter as you can in one
+minute. <br>
+Proper nouns will not count towards your total (proper nouns identify a single entity and
+are usually capitalized&mdash;for example, London, Jupiter, Sarah, and Microsoft). <br>
+When you are ready, please press the spacebar and we will show you the letter. <br>
+<em>Press the space bar to begin.</em>

--- a/baseline/client/verbal-fluency/frag/instruction.html
+++ b/baseline/client/verbal-fluency/frag/instruction.html
@@ -4,5 +4,5 @@ You will be asked to type as many words starting with one particular letter as y
 minute. <br>
 Proper nouns will not count towards your total (proper nouns identify a single entity and
 are usually capitalized&mdash;for example, London, Jupiter, Sarah, and Microsoft). <br>
-When you are ready, please press the spacebar and we will show you the letter. <br>
+When you are ready, please press the space bar and we will show you the letter. <br>
 <em>Press the space bar to begin.</em>

--- a/baseline/client/verbal-fluency/frag/introduction.html
+++ b/baseline/client/verbal-fluency/frag/introduction.html
@@ -1,0 +1,2 @@
+Welcome to the Verbal Fluency Task! <br>
+<em>Press the space bar to continue.</em>

--- a/baseline/client/verbal-fluency/frag/stimulus-template.html
+++ b/baseline/client/verbal-fluency/frag/stimulus-template.html
@@ -1,0 +1,2 @@
+Starting now, type as many words starting with <strong>{letter}</strong> as you can in one minute. <br>
+Please put a space or a line break between each word.

--- a/baseline/client/verbal-fluency/verbal-fluency.js
+++ b/baseline/client/verbal-fluency/verbal-fluency.js
@@ -24,7 +24,7 @@ function trial(letter) {
     return {
         type: "timed-writing",
         duration: 60000,
-        stimulus: stimulus_template_html.replace("{letter}", letter),
+        stimulus: stimulus_template_html.replaceAll("{letter}", letter),
         textarea_rows: 6,
         textarea_cols: 60,
         data: { letter: letter },

--- a/baseline/client/verbal-fluency/verbal-fluency.js
+++ b/baseline/client/verbal-fluency/verbal-fluency.js
@@ -7,8 +7,8 @@ const test = {
     type: "timed-writing",
     duration: 60000,
     stimulus: "uwu",
-    textarea_rows: 5,
-    textarea_cols: 40,
+    textarea_rows: 6,
+    textarea_cols: 60,
 };
 
 jsPsych.init({

--- a/baseline/client/verbal-fluency/verbal-fluency.js
+++ b/baseline/client/verbal-fluency/verbal-fluency.js
@@ -1,19 +1,48 @@
 import "@adp-psych/jspsych/jspsych.js";
+import "@adp-psych/jspsych/plugins/jspsych-html-keyboard-response.js";
 import "js/jspsych-timed-writing.js";
 import "@adp-psych/jspsych/css/jspsych.css";
 import "css/jspsych-timed-writing.css";
+import introduction_html from "./frag/introduction.html";
+import instruction_html from "./frag/instruction.html";
+import stimulus_template_html from "./frag/stimulus-template.html";
+import completion_html from "./frag/completion.html";
 
-const test = {
-    type: "timed-writing",
-    duration: 60000,
-    stimulus: "uwu",
-    textarea_rows: 6,
-    textarea_cols: 60,
+const introduction = {
+    type: "html-keyboard-response",
+    stimulus: introduction_html,
+    choices: [" "],
+};
+
+const instruction = {
+    type: "html-keyboard-response",
+    stimulus: instruction_html,
+    choices: [" "],
+};
+
+function trial(letter) {
+    return {
+        type: "timed-writing",
+        duration: 60000,
+        stimulus: stimulus_template_html.replace("{letter}", letter),
+        textarea_rows: 6,
+        textarea_cols: 60,
+        data: { letter: letter },
+    };
+}
+
+const completion = {
+    type: "html-keyboard-response",
+    stimulus: completion_html,
+    choices: [" "],
 };
 
 jsPsych.init({
     timeline: [
-        test,
+        introduction,
+        instruction,
+        trial("u"),
+        completion,
     ],
     on_finish: () => { jsPsych.data.displayData("json"); },
 });

--- a/baseline/client/verbal-fluency/verbal-fluency.js
+++ b/baseline/client/verbal-fluency/verbal-fluency.js
@@ -1,0 +1,18 @@
+import "@adp-psych/jspsych/jspsych.js";
+import "js/jspsych-timed-writing.js";
+import "@adp-psych/jspsych/css/jspsych.css";
+
+const test = {
+    type: "timed-writing",
+    duration: 60000,
+    stimulus: "uwu",
+    textarea_rows: 5,
+    textarea_cols: 40,
+};
+
+jsPsych.init({
+    timeline: [
+        test,
+    ],
+    on_finish: () => { jsPsych.data.displayData("json"); },
+});

--- a/baseline/client/verbal-fluency/verbal-fluency.js
+++ b/baseline/client/verbal-fluency/verbal-fluency.js
@@ -1,6 +1,7 @@
 import "@adp-psych/jspsych/jspsych.js";
 import "js/jspsych-timed-writing.js";
 import "@adp-psych/jspsych/css/jspsych.css";
+import "css/jspsych-timed-writing.css";
 
 const test = {
     type: "timed-writing",

--- a/baseline/dev-tools/local-server/public/index.html
+++ b/baseline/dev-tools/local-server/public/index.html
@@ -6,6 +6,7 @@
 <body>
     <ul>
         <li><a href="flanker/">Flanker</a>
+        <li><a href="verbal-fluency/">Verbal Fluency</a>
     </ul>
 </body>
 </html>

--- a/baseline/dev-tools/local-server/webpack.config.js
+++ b/baseline/dev-tools/local-server/webpack.config.js
@@ -9,12 +9,21 @@ module.exports = {
             import: path.join(client, "flanker/flanker.js"),
             filename: "flanker/flanker.bundle.js",
         },
+        "verbal-fluency": {
+            import: path.join(client, "verbal-fluency/verbal-fluency.js"),
+            filename: "verbal-fluency/verbal-fluency.bundle.js",
+        }
     },
     plugins: [
         new HtmlWebpackPlugin({
             title: "Flanker Task",
             filename: "flanker/index.html",
             chunks: ["flanker"],
+        }),
+        new HtmlWebpackPlugin({
+            title: "Verbal Fluency Task",
+            filename: "verbal-fluency/index.html",
+            chunks: ["verbal-fluency"],
         }),
         new HtmlWebpackPlugin({
             filename: "index.html",
@@ -39,7 +48,10 @@ module.exports = {
         ],
     },
     resolve: {
-        modules: [path.join(__dirname, "node_modules")],
+        modules: [
+            client,
+            path.join(__dirname, "node_modules"),
+        ],
     },
     output: {
         path: path.join(__dirname, "dist"),

--- a/baseline/dev-tools/local-server/webpack.config.js
+++ b/baseline/dev-tools/local-server/webpack.config.js
@@ -31,6 +31,11 @@ module.exports = {
             chunks: [],
         }),
     ],
+    optimization: {
+        splitChunks: {
+            chunks: "all",
+        },
+    },
     module: {
         rules: [
             {


### PR DESCRIPTION
Sorry, it might've been better to break this pull request up into pieces.

Here are the 9 changed files:
- `baseline/client/css/jspsych-timed-writing.css` and `baseline/client/js/jspsych-timed-writing.js` are both parts of a custom jsPysch plugin, `"timed-writing"`.
- The four files inside of `baseline/client/verbal-fluency/frag/` are customizable HTML fragments, same as the Flanker task's.
- `baseline/client/verbal-fluency/verbal-fluency.js` is the task's entry point.
- A link to `verbal-fluency/` was added to `baseline/dev-tools/local-server/public/index.html`.
- The changes to `baseline/dev-tools/local-server/webpack.config.js` is mostly boilerplate. I should add some code here to reduce this. Besides the boilerplate, the `client` path variable is added to `module.exports.resolve.modules`. This was done so that imports for files inside `/baseline/client/css/` or `/baseline/client/js/` resolve.