### PR TITLE
fix jspsych-percent-sum.js field font-size and parsing

### DIFF
--- a/baseline/client/css/jspsych-percent-sum.css
+++ b/baseline/client/css/jspsych-percent-sum.css
@@ -8,10 +8,11 @@
 }
 .jspsych-percent-sum-field {
     margin: .5rem;
+    font-size: 1em;
 }
 
 #jspsych-percent-sum-button {
-    display:block;
+    display: block;
     margin: 5% auto 5%;
 }
 

--- a/baseline/client/js/jspsych-percent-sum.js
+++ b/baseline/client/js/jspsych-percent-sum.js
@@ -20,6 +20,10 @@ jsPsych.plugins["percent-sum"] = (() => {
         },
     };
 
+    plugin.parseField = text => {
+        return parseInt(text, 10);
+    };
+
     plugin.trial = (display_element, trial) => {
         // throw if fields are malformed
         if (trial.fields.length < 1) {
@@ -51,7 +55,7 @@ jsPsych.plugins["percent-sum"] = (() => {
         const counter = display_element.querySelector("#jspsych-percent-sum-counter");
         // define validation helper for event listeners
         const percent_sum = () => {
-            return Array.from(inputs).reduce((sum, inp) => sum + parseInt(inp.value, 10), 0);
+            return Array.from(inputs).reduce((sum, inp) => sum + plugin.parseField(inp.value), 0);
         };
         // add input listeners
         inputs.forEach(inp => {

--- a/baseline/client/js/jspsych-percent-sum.js
+++ b/baseline/client/js/jspsych-percent-sum.js
@@ -22,7 +22,7 @@ jsPsych.plugins["percent-sum"] = (() => {
 
     plugin.parseField = text => {
         if (text === "") {
-            return 0;
+            return NaN;
         } else if (Array.from(text).every(c => "0" <= c && c <= "9")) {
             return parseInt(text, 10);
         } else {

--- a/baseline/client/js/jspsych-percent-sum.js
+++ b/baseline/client/js/jspsych-percent-sum.js
@@ -21,7 +21,13 @@ jsPsych.plugins["percent-sum"] = (() => {
     };
 
     plugin.parseField = text => {
-        return parseInt(text, 10);
+        if (text === "") {
+            return 0;
+        } else if (Array.from(text).every(c => "0" <= c && c <= "9")) {
+            return parseInt(text, 10);
+        } else {
+            return NaN;
+        }
     };
 
     plugin.trial = (display_element, trial) => {

--- a/baseline/client/tests/jspsych-percent-sum.test.js
+++ b/baseline/client/tests/jspsych-percent-sum.test.js
@@ -97,8 +97,8 @@ describe("parseField helper", () => {
         expect(typeof parseField).toBeDefined;
     });
 
-    it("parses empty string as 0", () => {
-        expect(parseField("")).toBe(0);
+    it("returns NaN on empty string", () => {
+        expect(parseField("")).toBe(NaN);
     });
 
     it("parses non-negative integers", () => {
@@ -114,7 +114,7 @@ describe("parseField helper", () => {
     it("returns NaN on !(non-negative integers)", () => {
         expect(parseField("-1")).toBeNaN();
         expect(parseField(".")).toBeNaN();
-        expect(parseField(".1").toBeNaN();
+        expect(parseField(".1")).toBeNaN();
         expect(parseField("1.")).toBeNaN();
         expect(parseField("1.1")).toBeNaN();
         expect(parseField("e")).toBeNaN();

--- a/baseline/client/tests/jspsych-percent-sum.test.js
+++ b/baseline/client/tests/jspsych-percent-sum.test.js
@@ -118,7 +118,7 @@ describe("parseField helper", () => {
         expect(parseField("1.")).toBeNaN();
         expect(parseField("1.1")).toBeNaN();
         expect(parseField("e")).toBeNaN();
-        expect(parseField("e1")).toBeNaN
+        expect(parseField("e1")).toBeNaN();
         expect(parseField("1e")).toBeNaN();
         expect(parseField("1e1")).toBeNaN();
         expect(parseField("1234567890e")).toBeNaN();

--- a/baseline/client/tests/jspsych-percent-sum.test.js
+++ b/baseline/client/tests/jspsych-percent-sum.test.js
@@ -1,9 +1,9 @@
-require("@adp-psych/jspsych/jspsych.js");
-require("../js/jspsych-percent-sum.js");
+import "@adp-psych/jspsych/jspsych.js";
+import "js/jspsych-percent-sum.js";
 
 describe("jspsych-percent-sum.js plugin", () => {
     it("loads correctly", () => {
-        expect(typeof jsPsych.plugins["percent-sum"]).not.toBe("undefined");
+        expect(typeof jsPsych.plugins["percent-sum"]).toBeDefined;
     });
 
     it("shows preamble", () => {
@@ -87,5 +87,31 @@ describe("jspsych-percent-sum.js plugin", () => {
         expect(() => {
             jsPsych.init({timeline: [trial]});
         }).toThrow();
+    });
+});
+
+describe("parseField helper", () => {
+    const parseField = jsPsych.plugins["percent-sum"].parseField;
+
+    it("is defined", () => {
+        expect(typeof parseField).toBeDefined;
+    });
+
+    it("parses non-negative integers", () => {
+        expect(parseField("0")).toBe(0);
+        expect(parseField("1")).toBe(1);
+        expect(parseField("10")).toBe(10);
+        expect(parseField("1234567890")).toBe(1234567890);
+        expect(parseField("08")).toBe(8);
+        expect(parseField(Number.MAX_SAFE_INTEGER.toString())).toBe(Number.MAX_SAFE_INTEGER);
+    });
+
+    it("returns NaN on !(non-negative integers)", () => {
+        expect(parseField("")).toBeNaN();
+        expect(parseField("-1")).toBeNaN();
+        expect(parseField("1.1")).toBeNaN();
+        expect(parseField("1e1")).toBeNaN();
+        expect(parseField("1234567890e")).toBeNaN();
+        expect(parseField("uwu")).toBeNaN();
     });
 });

--- a/baseline/client/tests/jspsych-percent-sum.test.js
+++ b/baseline/client/tests/jspsych-percent-sum.test.js
@@ -113,7 +113,13 @@ describe("parseField helper", () => {
 
     it("returns NaN on !(non-negative integers)", () => {
         expect(parseField("-1")).toBeNaN();
+        expect(parseField(".")).toBeNaN();
+        expect(parseField(".1").toBeNaN();
+        expect(parseField("1.")).toBeNaN();
         expect(parseField("1.1")).toBeNaN();
+        expect(parseField("e")).toBeNaN();
+        expect(parseField("e1")).toBeNaN
+        expect(parseField("1e")).toBeNaN();
         expect(parseField("1e1")).toBeNaN();
         expect(parseField("1234567890e")).toBeNaN();
         expect(parseField("1,000")).toBeNaN();

--- a/baseline/client/tests/jspsych-percent-sum.test.js
+++ b/baseline/client/tests/jspsych-percent-sum.test.js
@@ -97,6 +97,10 @@ describe("parseField helper", () => {
         expect(typeof parseField).toBeDefined;
     });
 
+    it("parses empty string as 0", () => {
+        expect(parseField("")).toBe(0);
+    });
+
     it("parses non-negative integers", () => {
         expect(parseField("0")).toBe(0);
         expect(parseField("1")).toBe(1);
@@ -107,7 +111,6 @@ describe("parseField helper", () => {
     });
 
     it("returns NaN on !(non-negative integers)", () => {
-        expect(parseField("")).toBeNaN();
         expect(parseField("-1")).toBeNaN();
         expect(parseField("1.1")).toBeNaN();
         expect(parseField("1e1")).toBeNaN();

--- a/baseline/client/tests/jspsych-percent-sum.test.js
+++ b/baseline/client/tests/jspsych-percent-sum.test.js
@@ -105,6 +105,7 @@ describe("parseField helper", () => {
         expect(parseField("0")).toBe(0);
         expect(parseField("1")).toBe(1);
         expect(parseField("10")).toBe(10);
+        expect(parseField("1000")).toBe(1000);
         expect(parseField("1234567890")).toBe(1234567890);
         expect(parseField("08")).toBe(8);
         expect(parseField(Number.MAX_SAFE_INTEGER.toString())).toBe(Number.MAX_SAFE_INTEGER);
@@ -115,6 +116,9 @@ describe("parseField helper", () => {
         expect(parseField("1.1")).toBeNaN();
         expect(parseField("1e1")).toBeNaN();
         expect(parseField("1234567890e")).toBeNaN();
+        expect(parseField("1,000")).toBeNaN();
+        expect(parseField("1 000")).toBeNaN();
+        expect(parseField(" ")).toBeNaN();
         expect(parseField("uwu")).toBeNaN();
     });
 });


### PR DESCRIPTION
Addresses #16 and #18.

This became kind of a mess because I didn't realize that [HTML number inputs containing invalid numbers have their values set to the empty string](https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)). Basically, `parseField` was passing tests on bad arguments, but it didn't behave the same way in the trial because there `parseField` was just getting `""` instead.