### PR TITLE
fix ua-parser-js version to 0.7.28 for security

### DIFF
--- a/baseline/client/package.json
+++ b/baseline/client/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@adp-psych/jspsych": "^6.3.1",
-    "ua-parser-js": "^0.7.28"
+    "ua-parser-js": "0.7.28"
   },
   "jest": {
     "rootDir": ".",


### PR DESCRIPTION
https://github.com/faisalman/ua-parser-js/issues/536#issuecomment-949667126
> Update - `^0.7.28` range is dangerous, `0.7.29` version already published.
> 
> We all need to fix `0.7.28` in our dependencies.

How spooky!

Found it through the [post on r/programming](https://www.reddit.com/r/programming/comments/qdlela/breaking_npm_package_uaparserjs_with_more_than_7m/), which scared the daylights out of me.