### PR TITLE
replace replaceAll w/ replace for compatibility

### DIFF
--- a/baseline/client/package-lock.json
+++ b/baseline/client/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@adp-psych/jspsych": "^6.3.1",
-        "ua-parser-js": "^0.7.28"
+        "ua-parser-js": "0.7.28"
       },
       "devDependencies": {
         "@babel/plugin-transform-regenerator": "^7.14.5",

--- a/baseline/client/verbal-fluency/verbal-fluency.js
+++ b/baseline/client/verbal-fluency/verbal-fluency.js
@@ -16,7 +16,7 @@ export class VerbalFluency {
         return {
             type: "timed-writing",
             duration: 60000,
-            stimulus: stimulus_template_html.replaceAll("{letter}", this.letter),
+            stimulus: stimulus_template_html.replace(/{letter}/g, this.letter),
             textarea_rows: 6,
             textarea_cols: 60,
             data: { letter: this.letter, isRelevant: true },

--- a/common/logger/package-lock.json
+++ b/common/logger/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "logger",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
I downgraded to Node.js 14.18.1 because I encountered [this](https://www.reddit.com/r/webdev/comments/qd14bm/node_17_currently_breaks_most_webpack/) with Node.js 17, and noticed that [`replaceAll`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) wasn't working.

[caniuse.com only gives 90.24% at the moment for `replaceAll`](https://caniuse.com/?search=replaceAll), and just using vanilla `replace` with a regex is a simple enough change.