### PR TITLE
remove instruction headers from verbal-learning HTML fragments

### DIFF
--- a/baseline/client/verbal-learning/frag/instruction_a_cue_animal.html
+++ b/baseline/client/verbal-learning/frag/instruction_a_cue_animal.html
@@ -1,3 +1,2 @@
-<h1>Instruction:</h1>
 Type all words from the first list that are animals. <br>
 <em>Click the button to begin.</em>

--- a/baseline/client/verbal-learning/frag/instruction_a_cue_furniture.html
+++ b/baseline/client/verbal-learning/frag/instruction_a_cue_furniture.html
@@ -1,3 +1,2 @@
-<h1>Instruction:</h1>
 Type all words from the first list that are furniture. <br>
 <em>Click the button to begin.</em>

--- a/baseline/client/verbal-learning/frag/instruction_a_cue_traveling.html
+++ b/baseline/client/verbal-learning/frag/instruction_a_cue_traveling.html
@@ -1,3 +1,2 @@
-<h1>Instruction:</h1>
 Type all words from the first list that are ways of traveling. <br>
 <em>Click the button to begin.</em>

--- a/baseline/client/verbal-learning/frag/instruction_a_cue_vegetable.html
+++ b/baseline/client/verbal-learning/frag/instruction_a_cue_vegetable.html
@@ -1,3 +1,2 @@
-<h1>Instruction:</h1>
 Type all words from the first list that are vegetables. <br>
 <em>Click the button to begin.</em>

--- a/baseline/client/verbal-learning/frag/instruction_a_immediate.html
+++ b/baseline/client/verbal-learning/frag/instruction_a_immediate.html
@@ -1,6 +1,5 @@
-<h1>Instruction:</h1>
-We are going to present a list of words to you.
-Listen carefully, because when we are through, we want you to type as many of the words as you can.
+Great, let's get started.
+Please listen carefully, because when we are through, we want you to type as many of the words as you can.
 You can type them in any order, just type as many of them as you can.
 Are you ready? <br>
 <em>Click the button to begin.</em>

--- a/baseline/client/verbal-learning/frag/instruction_a_immediate_rep.html
+++ b/baseline/client/verbal-learning/frag/instruction_a_immediate_rep.html
@@ -1,4 +1,3 @@
-<h1>Instruction:</h1>
 We are going to present the same list again.
 Like before, type as many of the words as you can, in any order, including words from the list you've typed in before. <br>
 <em>Click the button to begin.</em>

--- a/baseline/client/verbal-learning/frag/instruction_a_long.html
+++ b/baseline/client/verbal-learning/frag/instruction_a_long.html
@@ -1,4 +1,3 @@
-<h1>Instruction:</h1>
 We presented two different lists of words to you earlier: a first list that we presented several times, and a second list that we presented you once.
 Type all the words you can that were from the first list.
 Don’t type words from the second list, just the first list. <br>

--- a/baseline/client/verbal-learning/frag/instruction_a_short.html
+++ b/baseline/client/verbal-learning/frag/instruction_a_short.html
@@ -1,4 +1,3 @@
-<h1>Instruction:</h1>
 Now we want you to type all the words you can from the first list, the one we presented to you several times.
 Don’t type the words from the second list, just the first. <br>
 <em>Click the button to begin.</em>

--- a/baseline/client/verbal-learning/frag/instruction_b_immediate.html
+++ b/baseline/client/verbal-learning/frag/instruction_b_immediate.html
@@ -1,4 +1,3 @@
-<h1>Instruction:</h1>
 Now we are going to present a second list of words to you.
 When we are through, we want you to type as many words from this second list as you can, in any order.
 Don’t type words from the first list, just this second list. <br>


### PR DESCRIPTION
`baseline/client/verbal-learning/frag/instruction_a_immediate.html` is already edited for the verbal-learning audio check update.