### PR TITLE
avoid accidental timeouts in spatial-orientation tests

### DIFF
--- a/baseline/client/spatial-orientation/spatial-orientation.js
+++ b/baseline/client/spatial-orientation/spatial-orientation.js
@@ -75,6 +75,7 @@ export class SpatialOrientation {
 SpatialOrientation.taskName = "spatial-orientation";
 
 SpatialOrientation.stimulus = stimulus;
+SpatialOrientation.lingerDuration = 1000;
 
 SpatialOrientation.scenePositions = {
     "trash can": [0, 0],
@@ -109,6 +110,7 @@ SpatialOrientation.trial = (center, facing, target, mode, instruction = null, en
         SpatialOrientation.scenePositions[target],
     ),
     mode: mode,
+    lingerDuration: SpatialOrientation.lingerDuration,
     endTime: endTime,
     data: { isRelevant: mode === "test" },
 });

--- a/baseline/client/tests/daily-tasks.test.js
+++ b/baseline/client/tests/daily-tasks.test.js
@@ -464,13 +464,8 @@ describe("doing the tasks", () => {
             if (task.type === "html-keyboard-response") {
                 pressKey(" ");
             } else if (task.type === "spatial-orientation") {
-                const icirc = document.getElementById("jspsych-spatial-orientation-icirc");
-                if (icirc === null) {
-                    //we've been timed out
-                    break;
-                }
-                clickIcirc(icirc, 0, 0);
-                jest.runAllTimers();
+                clickIcirc(document.getElementById("jspsych-spatial-orientation-icirc"), 0, 0);
+                jest.advanceTimersByTime(task.lingerDuration);
             }
         }
         expect(saveResultsMock.mock.calls.length).toBe(24);

--- a/baseline/client/tests/spatial-orientation.test.js
+++ b/baseline/client/tests/spatial-orientation.test.js
@@ -31,6 +31,7 @@ describe("spatial-orientation", () => {
         // skip timeline to test block
         const timeline = (new SpatialOrientation(1)).getTimeline();
         jsPsych.init({timeline: timeline});
+        // actively progress trials until first test spatial-orientation trial is encountered
         for (const trial of timeline) {
             if (trial.data?.isRelevant === true) {
                 break;
@@ -38,10 +39,10 @@ describe("spatial-orientation", () => {
                 pressKey(" ");
             } else if (trial.type === "spatial-orientation") {
                 clickIcirc(document.getElementById("jspsych-spatial-orientation-icirc"), 0, 0);
-                jest.runAllTimers();
+                jest.advanceTimersByTime(trial.lingerDuration);
             }
         }
-        // expect test trials to NOT be completed at their start
+        // expect test trials to NOT be completed at first
         expect(jsPsych.data.get().filter({isRelevant: true}).values().length).toBe(0);
         // expect test trials to still NOT be completed after 4 minutes and 55 seconds
         advanceDateNowThenTimers(4*60*1000 + 55*1000);  // 4 minutes and 55 seconds


### PR DESCRIPTION
Calling `jest.runAllTimers` to get past a spatial-orientation trial's `lingerDuration` may result in the succeeding spatial-orientation trial completing with `timedout`. Fix by using `jest.advanceTimersByTime(trial.lingerDuration);` instead.

Also, a test was added to guarantee that the spatial-orientation task can be finished within the time limit (5 minutes) despite the minimum time necessary to wait out each spatial-orientation trial's `lingerDuration`.