### PR TITLE
remove unused n-back CSS rules

### DIFF
--- a/baseline/client/n-back/style.css
+++ b/baseline/client/n-back/style.css
@@ -1,11 +1,3 @@
-#jspsych-content {
-    max-width: 40em;
-}
-
-h1 {
-    font-size: 1.6em;
-}
-
 .n-back-cue-title {
     margin-top: 2em;
     font-weight: bold;


### PR DESCRIPTION
Headings were removed and the `#jspsych-content { max-width: 40em; }` is already set in `common.css`.