### PR TITLE
fix 2-back training instructions

### DIFF
--- a/baseline/client/n-back/frag/train/instruction_1a.html
+++ b/baseline/client/n-back/frag/train/instruction_1a.html
@@ -1,4 +1,4 @@
-In the second part of this task, your job is to press the space bar when the number on the screen is the same as the number immediately before the number currently on the screen. <br>
+In the third part of this task, your job is to press the spacebar when the number on the screen is the same as the number shown two numbers before it. <br>
 <br>
 For example, if you saw "5, 7, 7", you would press the space bar when the second 7 is on the screen. Let's give it a try. <br>
 <br>

--- a/baseline/client/n-back/frag/train/instruction_1a.html
+++ b/baseline/client/n-back/frag/train/instruction_1a.html
@@ -1,4 +1,4 @@
-In the third part of this task, your job is to press the spacebar when the number on the screen is the same as the number shown two numbers before it. <br>
+In the third part of this task, your job is to press the space bar when the number on the screen is the same as the number shown two numbers before it. <br>
 <br>
 For example, if you saw "5, 7, 7", you would press the space bar when the second 7 is on the screen. Let's give it a try. <br>
 <br>


### PR DESCRIPTION
Addresses #97.

The HTML fragment had 1-back instructions instead.