### PR TITLE
add verbal-fluency tests and use jest-raw-loader for HTML fragments

### DIFF
--- a/baseline/client/package-lock.json
+++ b/baseline/client/package-lock.json
@@ -24,6 +24,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.0.5",
         "jest-canvas-mock": "^2.3.1",
+        "jest-raw-loader": "^1.0.1",
         "mime-types": "^2.1.31",
         "style-loader": "^2.0.0",
         "webpack": "^5.40.0",
@@ -7722,6 +7723,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/jest-raw-loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jest-raw-loader/-/jest-raw-loader-1.0.1.tgz",
+      "integrity": "sha1-zp9W1UZQ8VfEp9FtIkul1hO81iY=",
+      "dev": true
     },
     "node_modules/jest-regex-util": {
       "version": "27.0.6",
@@ -18283,6 +18290,12 @@
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
       "dev": true,
       "requires": {}
+    },
+    "jest-raw-loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jest-raw-loader/-/jest-raw-loader-1.0.1.tgz",
+      "integrity": "sha1-zp9W1UZQ8VfEp9FtIkul1hO81iY=",
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.0.6",

--- a/baseline/client/package.json
+++ b/baseline/client/package.json
@@ -20,7 +20,6 @@
     ],
     "moduleNameMapper": {
       "\\.css$": "identity-obj-proxy",
-      "\\.html": "../../client/__mocks__/fileMock.js",
       "\\.png": "../../client/__mocks__/fileMock.js",
       "\\.wav": "../../client/__mocks__/fileMock.js",
       "\\.ogg": "../../client/__mocks__/fileMock.js",
@@ -28,7 +27,8 @@
     },
     "testEnvironment": "jsdom",
     "transform": {
-      "^.+\\.(js|jsx)$": "babel-jest"
+      "^.+\\.(js|jsx)$": "babel-jest",
+      "\\.html$": "jest-raw-loader"
     }
   },
   "devDependencies": {
@@ -44,6 +44,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.0.5",
     "jest-canvas-mock": "^2.3.1",
+    "jest-raw-loader": "^1.0.1",
     "mime-types": "^2.1.31",
     "style-loader": "^2.0.0",
     "webpack": "^5.40.0",

--- a/baseline/client/tests/flanker.test.js
+++ b/baseline/client/tests/flanker.test.js
@@ -1,4 +1,5 @@
 require("@adp-psych/jspsych/jspsych.js");
+import instruction6_html from "../flanker/frag/instruction-6.html";
 import { Flanker } from "../flanker/flanker.js";
 import { pressKey } from "./utils.js";
 
@@ -355,7 +356,7 @@ describe("flanker training with controlled randomization", () => {
         // final instruction screen -> fixation 1
         pressKey(" ");
         const data = jsPsych.data.get().last(1).values()[0];
-        expect(data.stimulus).toBe('test-file-stub');
+        expect(data.stimulus).toBe(instruction6_html);
     });
 
     it("randomizes the order of the trial stimuli", () => {

--- a/baseline/client/tests/task-classes.test.js
+++ b/baseline/client/tests/task-classes.test.js
@@ -38,7 +38,15 @@ describe.each([
     
     it(`${name} has taskName`, () => {
         expect(typeof taskClass.taskName).toBe("string");
-        const inst = new taskClass(1);
+        const args = (() => {
+            switch (taskClass) {
+                case VerbalFluency:
+                    return [VerbalFluency.possibleLetters[0]];
+                default:
+                    return [1];
+            }
+        })();
+        const inst = new taskClass(...args);
         expect(typeof inst.taskName).toBe("string");
     });
     

--- a/baseline/client/tests/task-switching.test.js
+++ b/baseline/client/tests/task-switching.test.js
@@ -1,4 +1,6 @@
 require("@adp-psych/jspsych/jspsych.js");
+import pre_exer_instr from "../task-switching/frag/pre_exercise_instruction.html";
+import pre_mix_instr from "../task-switching/frag/pre_mixed_instruction.html";
 import { TaskSwitching } from "../task-switching/task-switching.js";
 import { pressKey } from "./utils.js";
 
@@ -55,7 +57,7 @@ describe("TaskSwitching timeline", () => {
         confirmSingleBlock(10);
     });
     it("should show a screen introducing the exercise trials after the final 34 trials", () => {
-        expect(tl[11].stimulus).toBe('test-file-stub'); // blech - using imported html here prevents us from checking screen contents
+        expect(tl[11].stimulus).toBe(pre_exer_instr);
         expect(tl[11].timeline).toBeUndefined();
     });
     it("should show 16 trials of varying task types after the exercise trial intro screen", () => {
@@ -73,7 +75,7 @@ describe("TaskSwitching timeline", () => {
         expect(tl[28].timeline).toBeUndefined();
     });
     it("should show a screen introducing the main trials after the exercise trials", () => {
-        expect(tl[28].stimulus).toBe('test-file-stub'); // blech - again, using imported html here prevents us from checking screen contents
+        expect(tl[28].stimulus).toBe(pre_mix_instr);
         expect(tl[28].timeline).toBeUndefined();
     });
     it("should then show 4 blocks of 34 trials of varying task types with a countdown delay in between each block", () => {

--- a/baseline/client/tests/verbal-fluency.test.js
+++ b/baseline/client/tests/verbal-fluency.test.js
@@ -36,6 +36,16 @@ describe("verbal-fluency", () => {
         expect(data.response).toBe(response);
     });
 
+    it("displays the letter in the stimulus", () => {
+        VerbalFluency.possibleLetters.forEach(letter => {
+            jest.useFakeTimers("legacy");
+            startAtTimedWriting(letter);
+            console.log(document.querySelector("#jspsych-timed-writing-stimulus").innerHTML);
+            const displayedLetter = document.querySelector("#verbal-fluency-letter").textContent;
+            expect(displayedLetter).toBe(letter);
+        });
+    });
+
     it("should give the user 60 seconds to generate words", () => {
         // start at timed-writing trial
         jest.useFakeTimers("legacy");

--- a/baseline/client/tests/verbal-fluency.test.js
+++ b/baseline/client/tests/verbal-fluency.test.js
@@ -2,19 +2,17 @@ require("@adp-psych/jspsych/jspsych.js");
 import { VerbalFluency } from "../verbal-fluency/verbal-fluency.js";
 import { pressKey } from "./utils.js";
 
-jest.useFakeTimers('legacy'); // why legacy: https://github.com/facebook/jest/issues/11500
-
-beforeEach(() => {
-    let timeline = (new VerbalFluency(VerbalFluency.possibleLetters[0])).getTimeline();
-    expect(timeline.length).toBe(2);
-    jsPsych.init({timeline: timeline});
+const startAtTimedWriting = letter => {
+    jsPsych.init({timeline: (new VerbalFluency(letter)).getTimeline()});
     // instruction screen -> trial
     pressKey(" ");
-});
+};
 
 describe("verbal-fluency", () => {
     it("results should have at least one result marked isRelevant", () => {
-        // first trial
+        jest.useFakeTimers("legacy");  // why legacy: https://github.com/facebook/jest/issues/11500
+        startAtTimedWriting("f");
+        // timed writing trial
         const inputField = document.querySelector("#jspsych-timed-writing-textarea");
         inputField.value = "fee fi fo fum";
         // let's not wait 60 seconds for the trial to finish
@@ -25,7 +23,9 @@ describe("verbal-fluency", () => {
     });
 
     it("should give the user 60 seconds to generate words", () => {
-        //expect(setTimeout).toHaveBeenCalledTimes(1);
+        jest.useFakeTimers("legacy");
+        startAtTimedWriting(VerbalFluency.possibleLetters[0]);
+        //expect(setTimeout).toHaveBeenCalledTimes(1);  // display timer prevents this
         expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 60000);
     });
 });

--- a/baseline/client/tests/verbal-fluency.test.js
+++ b/baseline/client/tests/verbal-fluency.test.js
@@ -22,6 +22,20 @@ describe("verbal-fluency", () => {
         expect(relevantData.length).toBe(1);
     });
 
+    it("records letter prompt and user response", () => {
+        // prepare letter and response
+        const letter = "c";
+        const response = "change da world\nmy final message. Goodb ye";
+        // run task
+        startAtTimedWriting(letter);
+        document.querySelector("#jspsych-timed-writing-textarea").value = response;
+        jest.runAllTimers();
+        // check data
+        const data = jsPsych.data.get().filter({isRelevant: true}).values()[0];
+        expect(data.letter).toBe(letter);
+        expect(data.response).toBe(response);
+    });
+
     it("should give the user 60 seconds to generate words", () => {
         jest.useFakeTimers("legacy");
         startAtTimedWriting(VerbalFluency.possibleLetters[0]);

--- a/baseline/client/tests/verbal-fluency.test.js
+++ b/baseline/client/tests/verbal-fluency.test.js
@@ -8,9 +8,16 @@ const startAtTimedWriting = letter => {
     pressKey(" ");
 };
 
+beforeEach(() => {
+    jest.useFakeTimers("legacy");  // why legacy: https://github.com/facebook/jest/issues/11500
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
 describe("verbal-fluency", () => {
     it("results should have at least one result marked isRelevant", () => {
-        jest.useFakeTimers("legacy");  // why legacy: https://github.com/facebook/jest/issues/11500
         startAtTimedWriting("f");
         // timed writing trial
         const inputField = document.querySelector("#jspsych-timed-writing-textarea");
@@ -38,7 +45,6 @@ describe("verbal-fluency", () => {
 
     it("displays the letter in the stimulus", () => {
         VerbalFluency.possibleLetters.forEach(letter => {
-            jest.useFakeTimers("legacy");
             startAtTimedWriting(letter);
             const displayedLetter = document.querySelector("#verbal-fluency-letter").textContent;
             expect(displayedLetter).toBe(letter);
@@ -47,7 +53,6 @@ describe("verbal-fluency", () => {
 
     it("should give the user 60 seconds to generate words", () => {
         // start at timed-writing trial
-        jest.useFakeTimers("legacy");
         let finished = false;
         jsPsych.init({
             timeline: (new VerbalFluency(VerbalFluency.possibleLetters[0])).getTimeline(),

--- a/baseline/client/tests/verbal-fluency.test.js
+++ b/baseline/client/tests/verbal-fluency.test.js
@@ -5,7 +5,7 @@ import { pressKey } from "./utils.js";
 jest.useFakeTimers('legacy'); // why legacy: https://github.com/facebook/jest/issues/11500
 
 beforeEach(() => {
-    let timeline = (new VerbalFluency()).getTimeline();
+    let timeline = (new VerbalFluency(VerbalFluency.possibleLetters[0])).getTimeline();
     expect(timeline.length).toBe(2);
     jsPsych.init({timeline: timeline});
     // instruction screen -> trial

--- a/baseline/client/tests/verbal-fluency.test.js
+++ b/baseline/client/tests/verbal-fluency.test.js
@@ -37,9 +37,22 @@ describe("verbal-fluency", () => {
     });
 
     it("should give the user 60 seconds to generate words", () => {
+        // start at timed-writing trial
         jest.useFakeTimers("legacy");
-        startAtTimedWriting(VerbalFluency.possibleLetters[0]);
-        //expect(setTimeout).toHaveBeenCalledTimes(1);  // display timer prevents this
+        let finished = false;
+        jsPsych.init({
+            timeline: (new VerbalFluency(VerbalFluency.possibleLetters[0])).getTimeline(),
+            on_finish: () => { finished = true; },
+        });
+        pressKey(" ");
+        // check mocked setTimeout (slightly fragile)
+        //expect(setTimeout).toHaveBeenCalledTimes(1);  // display timer code prevents this
         expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 60000);
+        // check finished
+        expect(finished).toBe(false);  // should not be finished at the start
+        jest.advanceTimersByTime(59000);
+        expect(finished).toBe(false);  // should not be finished after 59 seconds
+        jest.advanceTimersByTime(2000);
+        expect(finished).toBe(true);  // should be finished after 61 seconds
     });
 });

--- a/baseline/client/tests/verbal-fluency.test.js
+++ b/baseline/client/tests/verbal-fluency.test.js
@@ -40,7 +40,6 @@ describe("verbal-fluency", () => {
         VerbalFluency.possibleLetters.forEach(letter => {
             jest.useFakeTimers("legacy");
             startAtTimedWriting(letter);
-            console.log(document.querySelector("#jspsych-timed-writing-stimulus").innerHTML);
             const displayedLetter = document.querySelector("#verbal-fluency-letter").textContent;
             expect(displayedLetter).toBe(letter);
         });

--- a/baseline/client/verbal-fluency/frag/stimulus-template.html
+++ b/baseline/client/verbal-fluency/frag/stimulus-template.html
@@ -1,2 +1,2 @@
-Starting now, type as many words starting with <strong>{letter}</strong> as you can in one minute. <br>
+Starting now, type as many words starting with <span id="verbal-fluency-letter">{letter}</span> as you can in one minute. <br>
 Please put a space or a line break between each word.

--- a/baseline/client/verbal-fluency/style.css
+++ b/baseline/client/verbal-fluency/style.css
@@ -1,0 +1,3 @@
+#verbal-fluency-letter {
+    font-weight: bold;
+}

--- a/baseline/client/verbal-fluency/verbal-fluency.js
+++ b/baseline/client/verbal-fluency/verbal-fluency.js
@@ -4,6 +4,7 @@ import "../js/jspsych-timed-writing.js";
 import "@adp-psych/jspsych/css/jspsych.css";
 import "css/common.css";
 import "css/jspsych-timed-writing.css";
+import "./style.css";
 import instruction_html from "./frag/instruction.html";
 import stimulus_template_html from "./frag/stimulus-template.html";
 

--- a/baseline/client/verbal-fluency/verbal-fluency.js
+++ b/baseline/client/verbal-fluency/verbal-fluency.js
@@ -9,7 +9,11 @@ import stimulus_template_html from "./frag/stimulus-template.html";
 
 export class VerbalFluency {
     constructor(letter) {
-        this.letter = letter;
+        if (this.constructor.possibleLetters.includes(letter)) {
+            this.letter = letter;
+        } else {
+            throw new Error("unsupported letter");
+        }
     }
     
     trial() {


### PR DESCRIPTION
- The `VerbalFluency` constructor now throws when passed an unsupported letter.
- Added to timing test using `jest.advanceTimersByTime`. (Previously, this test only checked that `setTimeout` was called with an argument of `60000` ms.)
- Added test to check that the prompt letter and timed-writing response is recorded in data.
- Added test to check that the prompt letter is displayed in the timed-writing stimulus. (Consequently, HTML fragments are now correctly loaded as strings in Jest tests. Some tests for flanker and task-switching relied on HTML files being loaded as `"test-file-stub"`, so they had to be updated.)