### PR TITLE
run the timeline in verbal-learning test to check recorded data

### DIFF
--- a/baseline/client/face-name/stimuli.json
+++ b/baseline/client/face-name/stimuli.json
@@ -234,7 +234,7 @@
         },
         {
             "cat": "age18-29/Female",
-            "picId": "EMWfemale18-2neutral.jpg",
+            "picId": "EMWfemale18neutral.jpg",
             "name": "Jennifer",
             "lure": "Cynthia"
         },

--- a/baseline/client/face-name/stimuli.json
+++ b/baseline/client/face-name/stimuli.json
@@ -48,7 +48,7 @@
             "cat": "age 30-49/Female",
             "picId": "EMBfemale33neutral.jpg",
             "name": "Ashley",
-            "lure": "Carol"
+            "lure": "Dorothy"
         },
         {
             "cat": "age 50-69/Male",

--- a/baseline/client/js/jspsych-memory-field.js
+++ b/baseline/client/js/jspsych-memory-field.js
@@ -46,6 +46,9 @@ jsPsych.plugins["memory-field"] = (() => {
         });
         // add button listener
         button.addEventListener("click", () => {
+            if (field.value) {
+                memory.push(field.value);
+            }
             const data = {
                 stimulus: trial.stimulus,
                 response: memory,

--- a/baseline/client/js/jspsych-memory-field.js
+++ b/baseline/client/js/jspsych-memory-field.js
@@ -20,7 +20,7 @@ jsPsych.plugins["memory-field"] = (() => {
         {
             let html = "";
             html += `<div id="jspsych-memory-field-stimulus">${trial.stimulus}</div>`;
-            html += `<input type="text" id="jspsych-memory-field-field">`;
+            html += `<input type="text" id="jspsych-memory-field-field" autocomplete="off">`;
             html += `<div id="jspsych-memory-field-button-wrapper">`;
             html += `<input type="button" id="jspsych-memory-field-button" class="jspsych-btn" value="${trial.button_label}">`;
             html += `</div>`;

--- a/baseline/client/package-lock.json
+++ b/baseline/client/package-lock.json
@@ -26,6 +26,7 @@
         "jest-canvas-mock": "^2.3.1",
         "jest-raw-loader": "^1.0.1",
         "mime-types": "^2.1.31",
+        "regenerator-runtime": "^0.13.9",
         "style-loader": "^2.0.0",
         "webpack": "^5.40.0",
         "webpack-cli": "^4.7.2",
@@ -9825,9 +9826,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
       "dev": true
     },
     "node_modules/regenerator-transform": {
@@ -19938,9 +19939,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
       "dev": true
     },
     "regenerator-transform": {

--- a/baseline/client/package.json
+++ b/baseline/client/package.json
@@ -46,6 +46,7 @@
     "jest-canvas-mock": "^2.3.1",
     "jest-raw-loader": "^1.0.1",
     "mime-types": "^2.1.31",
+    "regenerator-runtime": "^0.13.9",
     "style-loader": "^2.0.0",
     "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2",

--- a/baseline/client/physical-activity/physical-activity.js
+++ b/baseline/client/physical-activity/physical-activity.js
@@ -65,23 +65,26 @@ PhysicalActivity.form = `
         <br/>
     </div>
 
-    <label for="weight">Body weight (lbs.): </label>
-    <input type="number" min="50" max="300" name="weight" id="weight" required="true">
-    <br/>
-    Height: <input type="number" min="2" max="8" name="height_feet" id="height_feet" required="true">
-    <label for="height_feet">feet</label>
-    <input type="number" min="0" max="11" name="height_inches" id="height_inches" required="true">
-    <label for="height_inches">inches</label>
-    <br/>
-    Age: <input type="number" min="18" max="100" name="age" id="age" required="true">
-    <label for="age">years old</label>
-    <br/>
-    <label for="gender">Gender</label>
-    <select name="gender" id="gender" required="true">
-        <option value="" selected>Please select</option>
-        <option value="0">Male</option>
-        <option value="1">Female</option>
-    </select>
+    <div>
+        <p>Please fill in the appropriate values for yourself for the following variables:</p>
+        <label for="weight">Body weight (lbs.): </label>
+        <input type="number" min="50" max="300" name="weight" id="weight" required="true">
+        <br/>
+        Height: <input type="number" min="2" max="8" name="height_feet" id="height_feet" required="true">
+        <label for="height_feet">feet</label>
+        <input type="number" min="0" max="11" name="height_inches" id="height_inches" required="true">
+        <label for="height_inches">inches</label>
+        <br/>
+        Age: <input type="number" min="18" max="100" name="age" id="age" required="true">
+        <label for="age">years old</label>
+        <br/>
+        <label for="gender">Gender</label>
+        <select name="gender" id="gender" required="true">
+            <option value="" selected>Please select</option>
+            <option value="0">Male</option>
+            <option value="1">Female</option>
+        </select>
+    </div>
 </div>
 `;
 

--- a/baseline/client/spatial-orientation/frag/test_instruction.html
+++ b/baseline/client/spatial-orientation/frag/test_instruction.html
@@ -2,6 +2,6 @@ Now you will do the test.
 There are 12 items on this test.
 You will have 5 minutes to complete these items.
 <br>
-Please try to response accurately, but do not spend too much time on any one item.
+Please try to respond accurately, but do not spend too much time on any one item.
 <br>
 <em>Press the space bar to begin the test trials.</em>

--- a/baseline/client/tests/jspsych-memory-field.test.js
+++ b/baseline/client/tests/jspsych-memory-field.test.js
@@ -76,4 +76,13 @@ describe("jspsych-memory-field.js plugin", () => {
         document.getElementById("jspsych-memory-field-button").click();
         expect(finished).toBe(true);
     });
+
+    it("disables autocomplete", () => {
+        jsPsych.init({timeline: [{
+            type: "memory-field",
+            stimulus: "",
+            button_label: "",
+        }]});
+        expect(document.getElementById("jspsych-memory-field-field").autocomplete).toBe("off");
+    });
 });

--- a/baseline/client/tests/jspsych-memory-field.test.js
+++ b/baseline/client/tests/jspsych-memory-field.test.js
@@ -38,6 +38,30 @@ describe("jspsych-memory-field.js plugin", () => {
         expect(data.response).toStrictEqual(responses);
     });
 
+    it("records lingering response in input field", () => {
+        const response = "my enter key is broken";
+        jsPsych.init({timeline: [{
+            type: "memory-field",
+            stimulus: "",
+            button_label: "",
+        }]});
+        document.getElementById("jspsych-memory-field-field").value = response;
+        document.getElementById("jspsych-memory-field-button").click();
+        const data = jsPsych.data.getLastTrialData().values()[0];
+        expect(data.response).toStrictEqual([response]);
+    });
+
+    it("records nothing for no response in input field", () => {
+        jsPsych.init({timeline: [{
+            type: "memory-field",
+            stimulus: "",
+            button_label: "",
+        }]});
+        document.getElementById("jspsych-memory-field-button").click();
+        const data = jsPsych.data.getLastTrialData().values()[0];
+        expect(data.response).toStrictEqual([]);
+    });
+
     it("finishes when button is pressed", () => {
         let finished = false;
         jsPsych.init({

--- a/baseline/client/tests/task-classes.test.js
+++ b/baseline/client/tests/task-classes.test.js
@@ -42,6 +42,8 @@ describe.each([
             switch (taskClass) {
                 case VerbalFluency:
                     return [VerbalFluency.possibleLetters[0]];
+                case VerbalLearning:
+                    return [1, 1];
                 default:
                     return [1];
             }

--- a/baseline/client/tests/verbal-learning.test.js
+++ b/baseline/client/tests/verbal-learning.test.js
@@ -1,6 +1,7 @@
 import { VerbalLearning } from "../verbal-learning/verbal-learning.js";
 import instruction_check_loop_html from "../verbal-learning/frag/instruction_check_loop.html";
 import { pressKey } from "./utils.js";
+import "regenerator-runtime/runtime";
 
 // mock away annoying plugins with a dummy
 const dummyPlugin = {

--- a/baseline/client/tests/verbal-learning.test.js
+++ b/baseline/client/tests/verbal-learning.test.js
@@ -55,25 +55,6 @@ describe("verbal-learning", () => {
         // get timelines for segments 1 and 2
         const timeline1 = (new VerbalLearning(1, 1)).getTimeline();
         const timeline2 = (new VerbalLearning(1, 2, () => Date.now())).getTimeline();
-        // test timeline nodes for relevant data
-        const timelineHasRelevantData = timeline => {
-            for (const node of timeline) {
-                if (node.timeline === undefined) {
-                    // node is a trial, hopefully
-                    if (node.data && node.data.isRelevant) {
-                        return true;
-                    }
-                } else {
-                    // node is a timeline, hopefully... recurse!
-                    if (timelineHasRelevantData(node.timeline)) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        };
-        expect(timelineHasRelevantData(timeline1)).toBe(true);
-        expect(timelineHasRelevantData(timeline2)).toBe(true);
         // test recorded data for relevant data
         const recordRelevantDataFromTimeline = async timeline => {
             let finished = false;

--- a/baseline/client/tests/verbal-learning.test.js
+++ b/baseline/client/tests/verbal-learning.test.js
@@ -1,12 +1,55 @@
-require("@adp-psych/jspsych/jspsych.js");
 import { VerbalLearning } from "../verbal-learning/verbal-learning.js";
+import instruction_check_loop_html from "../verbal-learning/frag/instruction_check_loop.html";
+import { pressKey } from "./utils.js";
+
+// mock away annoying plugins with a dummy
+const dummyPlugin = {
+    info: {name: "dummy", parameters: {}},
+    trial: () => { jsPsych.finishTrial({}); },
+};
+jsPsych.plugins["preload"] = dummyPlugin;
+jsPsych.plugins["audio-keyboard-response"] = dummyPlugin;
+
+const completeCurrentTrial = () => {
+    const trial = jsPsych.currentTrial();
+    const progress = jsPsych.progress();
+    if (trial.type === "html-keyboard-response") {
+        if (typeof trial.trial_duration === "number") {
+            jest.advanceTimersByTime(trial.trial_duration);
+        } else {
+            pressKey(trial.choices[0]);
+        }
+    } else if (trial.type === "html-button-response") {
+        // click "Sound Worked Fine"
+        jsPsych.getDisplayElement().querySelectorAll("button")[1].click();
+    } else if (trial.type === "audio-keyboard-response") {
+        // audio plugin is mocked to finish trial immediately
+    } else if (trial.type === "countdown") {
+        jest.advanceTimersByTime(trial.duration);
+    } else if (trial.type === "memory-field") {
+        document.getElementById("jspsych-memory-field-button").click();
+    }
+    // assert that progress occurred
+    if (jsPsych.progress().current_trial_global <= progress.current_trial_global) {
+        console.log(trial);
+        throw Error("progress didn't increase");
+    }
+};
+
+beforeEach(() => {
+    jest.useFakeTimers("legacy");
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
 
 describe("verbal-learning", () => {
     it("results should have at least one result marked isRelevant", () => {
-        const timeline = [
-            {timeline: new VerbalLearning(1, 1).getTimeline()},
-            {timeline: new VerbalLearning(1, 2, () => Date.now()).getTimeline()},
-        ];
+        // get timelines for segments 1 and 2
+        const timeline1 = (new VerbalLearning(1, 1)).getTimeline();
+        const timeline2 = (new VerbalLearning(1, 2, () => Date.now())).getTimeline();
+        // test timeline nodes for relevant data
         const timelineHasRelevantData = timeline => {
             for (const node of timeline) {
                 if (node.timeline === undefined) {
@@ -23,32 +66,23 @@ describe("verbal-learning", () => {
             }
             return false;
         };
-        expect(timelineHasRelevantData(timeline)).toBe(true);
-
-        // TODO find a way to mock the audio-keyboard-response plugin
-        // so that the below doesn't complain about failure to load audio files
-        // let timeline = (new VerbalLearning()).getTimeline();
-        // // drop the preload step - jest doesn't play nicely with it
-        // timeline = timeline.slice(1);
-        // expect(timeline.length).toBe(40);
-        // jsPsych.init({timeline: timeline});
-
-        // for (let i = 0; i < timeline.length; i++) {
-        //     const trial = jsPsych.currentTrial();
-        //     if (trial.type === 'html-button-response')  {
-        //         clickContinue();
-        //     } else if (trial.type === 'memory-field') {
-        //         clickContinue("#jspsych-memory-field-button")
-        //     } else if (trial.type === 'audio-keyboard-response') {
-        //         jsPsych.finishTrial();
-        //     } else {
-        //         console.error(trial);
-        //         throw new Error(`Unexpected trial type '${trial.type}'.`);
-        //     }
-        // }
-
-        // // check the data
-        // const relevantData = jsPsych.data.get().filter({isRelevant: true}).values();
-        // expect(relevantData.length).toBeGreaterThan(0);
+        expect(timelineHasRelevantData(timeline1)).toBe(true);
+        expect(timelineHasRelevantData(timeline2)).toBe(true);
+        // test recorded data for relevant data
+        const recordRelevantDataFromTimeline = timeline => {
+            let finished = false;
+            jsPsych.init({
+                timeline: timeline,
+                on_finish: () => { finished = true; },
+            });
+            for (let trials = 0; !finished; ++trials) {
+                if (trials > 100) { throw new Error("too many trials"); }
+                completeCurrentTrial();
+            }
+            return jsPsych.data.get().filter({isRelevant: true}).values();
+            expect(relevant.length).toBeGreaterThan(0);
+        };
+        expect(recordRelevantDataFromTimeline(timeline1).length).toBeGreaterThan(0);
+        expect(recordRelevantDataFromTimeline(timeline2).length).toBeGreaterThan(0);
     });
 });

--- a/baseline/client/tests/verbal-learning.test.js
+++ b/baseline/client/tests/verbal-learning.test.js
@@ -26,14 +26,17 @@ const completeCurrentTrial = async () => {
     } else if (trial.type === "audio-keyboard-response") {
         // audio plugin is mocked to finish trial immediately
     } else if (trial.type === "call-function") {
+        await null;
     } else if (trial.type === "countdown") {
-        jest.advanceTimersByTime(trial.duration);
+        // countdown uses performance.now() so just un-disable the button
+        const button = document.getElementById("jspsych-countdown-button");
+        button.disabled = false;
+        button.click();
     } else if (trial.type === "memory-field") {
         document.getElementById("jspsych-memory-field-button").click();
     }
     // assert that progress occurred
     if (jsPsych.progress().current_trial_global <= progress.current_trial_global) {
-        console.log(trial);
         throw Error("progress didn't increase");
     }
 };

--- a/baseline/client/tests/verbal-learning.test.js
+++ b/baseline/client/tests/verbal-learning.test.js
@@ -26,7 +26,8 @@ const completeCurrentTrial = async () => {
     } else if (trial.type === "audio-keyboard-response") {
         // audio plugin is mocked to finish trial immediately
     } else if (trial.type === "call-function") {
-        await null;
+        // pause to allow the async function in the call-function trial to resolve???
+        await null;  // comment this out and the function will throw for the async call-function
     } else if (trial.type === "countdown") {
         // countdown uses performance.now() so just un-disable the button
         const button = document.getElementById("jspsych-countdown-button");
@@ -37,7 +38,7 @@ const completeCurrentTrial = async () => {
     }
     // assert that progress occurred
     if (jsPsych.progress().current_trial_global <= progress.current_trial_global) {
-        throw Error("progress didn't increase");
+        throw Error("progress didn't increase for trial " + JSON.stringify(trial));
     }
 };
 

--- a/baseline/client/tests/verbal-learning.test.js
+++ b/baseline/client/tests/verbal-learning.test.js
@@ -54,7 +54,7 @@ describe("verbal-learning", () => {
     it("results should have at least one result marked isRelevant", async () => {
         // get timelines for segments 1 and 2
         const timeline1 = (new VerbalLearning(1, 1)).getTimeline();
-        const timeline2 = (new VerbalLearning(1, 2, () => Date.now())).getTimeline();
+        const timeline2 = (new VerbalLearning(1, 2, Date.now)).getTimeline();
         // test recorded data for relevant data
         const recordRelevantDataFromTimeline = async timeline => {
             let finished = false;

--- a/baseline/client/verbal-learning/verbal-learning.js
+++ b/baseline/client/verbal-learning/verbal-learning.js
@@ -49,8 +49,8 @@ export class VerbalLearning {
             throw new Error("setNum must be a strictly positive integer");
         }
         // validate segmentNum and compute startTime
-        if (segmentNum < 1 || segmentNum > 2) {
-            throw new Error("segmentNum must be in 1..2");
+        if (!Number.isInteger(segmentNum) || segmentNum < 1 || segmentNum > 2) {
+            throw new Error("segmentNum must be an integer in 1..2");
         } else if (segmentNum === 1 && getLastSegmentEndTime !== null) {
             throw new Error("getLastSegmentEndTime must be null if segmentNum is 1");
         } else if (segmentNum === 2 && getLastSegmentEndTime === null) {

--- a/server/lambdas/serverless.yml
+++ b/server/lambdas/serverless.yml
@@ -93,7 +93,7 @@ functions:
       EMAIL_SENDER: "uscemotioncognitionlab@gmail.com"
       SNS_ENDPOINT: "https://sns.${self:provider.region}.amazonaws.com"
       SES_ENDPOINT: "https://email.${self:provider.region}.amazonaws.com"
-    role: ${ssm:/${self:service}/${self:provider.stage}/role/lambda/dynamodb}
+    role: ${ssm:/${self:service}/${self:provider.stage}/role/lambda/dynamodb/sns/ses}
     package:
       patterns:
         - 'reminders/*.js'


### PR DESCRIPTION
The `"results should have at least one result marked isRelevant"` test for verbal-learning now actually runs the timeline and checks the resulting recorded data, instead of only searching through the timeline's nodes' data objects.

Currently, this is achieved by simply overwriting the preload and audio-keyboard-response plugins with dummies. (The audio object used in the audio-keyboard-response plugin is NOT yet mocked out!)

In order to get the async call-function trial to resolve (I think?), I had to add an `await null;` statement to the `completeCurrentTrial` helper. This required rewriting many functions to be async, including the Jest test callback itself. Using the `async` keyword resulted in a `ReferenceError: regeneratorRuntime is not defined`, so [regenerator-runtime](https://www.npmjs.com/package/regenerator-runtime) was added as a dev dependency.