### PR TITLE
record important parameters in data for spatial-orientation trials

### DIFF
--- a/baseline/client/js/jspsych-spatial-orientation.js
+++ b/baseline/client/js/jspsych-spatial-orientation.js
@@ -169,11 +169,19 @@ jsPsych.plugins["spatial-orientation"] = (() => {
         }
         // compute timeLimit (duration) from trial.endTime (instant)
         const timeLimit = trial.endTime === null ? null : trial.endTime - Date.now();
+        // build trial params data
+        const paramsData = {
+            center: trial.centerText,
+            facing: trial.topText,
+            target: trial.pointerText,
+            mode: trial.mode,
+            timeLimit: timeLimit,
+        };
         // skip trial if timeLimit 
         if (trial.endTime !== null && timeLimit <= 0) {
             const data = {
+                ...paramsData,
                 completionReason: "skipped",
-                timeLimit: timeLimit,
             };
             jsPsych.finishTrial(data);
         } else {
@@ -206,8 +214,8 @@ jsPsych.plugins["spatial-orientation"] = (() => {
                     const rt = performance.now() - start;
                     const data = {
                         ...completionData,
+                        ...paramsData,
                         rt: rt,
-                        timeLimit: timeLimit,
                     };
                     // finish trial
                     setTimeout(() => { jsPsych.finishTrial(data); }, trial.lingerDuration);

--- a/baseline/client/js/jspsych-spatial-orientation.js
+++ b/baseline/client/js/jspsych-spatial-orientation.js
@@ -134,7 +134,6 @@ jsPsych.plugins["spatial-orientation"] = (() => {
                 const completionData = {
                     completionReason: "responded",
                     responseRadians: responseRadians,
-                    targetRadians: options.targetRadians,
                 };
                 // draw target pointer if practice
                 if (options.mode === "practice") {
@@ -175,6 +174,7 @@ jsPsych.plugins["spatial-orientation"] = (() => {
             facing: trial.topText,
             target: trial.pointerText,
             mode: trial.mode,
+            targetRadians: trial.targetRadians,
             timeLimit: timeLimit,
         };
         // skip trial if timeLimit 

--- a/baseline/client/tests/jspsych-spatial-orientation.test.js
+++ b/baseline/client/tests/jspsych-spatial-orientation.test.js
@@ -2,13 +2,20 @@ import "@adp-psych/jspsych/jspsych.js";
 import "js/jspsych-spatial-orientation.js";
 import "jest-canvas-mock";
 
+beforeEach(() => {
+    jest.useFakeTimers("legacy");
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
 describe("jspsych-spatial-orientation.js plugin", () => {
     it("loads correctly", () => {
         expect(jsPsych.plugins["spatial-orientation"]).toBeDefined();
     });
 
     it("registers clicks correctly", () => {
-        jest.useFakeTimers("legacy");
         const dataFromClick = (x, y) => {
             jsPsych.init({timeline: [{
                 type: "spatial-orientation",
@@ -61,7 +68,6 @@ describe("jspsych-spatial-orientation.js plugin", () => {
     });
     
     it("stops when encountering endTime", () => {
-        jest.useFakeTimers("legacy");
         jsPsych.init({timeline: [{
             type: "spatial-orientation",
             scene: "scene",
@@ -87,6 +93,25 @@ describe("jspsych-spatial-orientation.js plugin", () => {
         // expect completionReason to be "timedout"
         const data = jsPsych.data.getLastTrialData().values()[0];
         expect(data.completionReason).toBe("timedout");
+    });
+
+    it("records all important parameters", () => {
+        const trial = {
+            type: "spatial-orientation",
+            scene: "scene",
+            centerText: "a",
+            topText: "b",
+            pointerText: "c",
+            targetRadians: 0,
+            mode: "test",
+            endTime: -1,
+        };
+        jsPsych.init({timeline: [trial]});
+        const data = jsPsych.data.getLastTrialData().values()[0];
+        expect(data.center).toBe(trial.centerText);
+        expect(data.facing).toBe(trial.topText);
+        expect(data.target).toBe(trial.pointerText);
+        expect(data.mode).toBe(trial.mode);
     });
 });
 

--- a/baseline/client/tests/jspsych-spatial-orientation.test.js
+++ b/baseline/client/tests/jspsych-spatial-orientation.test.js
@@ -112,6 +112,8 @@ describe("jspsych-spatial-orientation.js plugin", () => {
         expect(data.facing).toBe(trial.topText);
         expect(data.target).toBe(trial.pointerText);
         expect(data.mode).toBe(trial.mode);
+        expect(typeof data.targetRadians).toBe("number");
+        expect(data.timeLimit).toBeLessThanOrEqual(0);
     });
 });
 

--- a/baseline/client/tests/jspsych-spatial-orientation.test.js
+++ b/baseline/client/tests/jspsych-spatial-orientation.test.js
@@ -96,6 +96,7 @@ describe("jspsych-spatial-orientation.js plugin", () => {
     });
 
     it("records all important parameters", () => {
+        // define trial params
         const trial = {
             type: "spatial-orientation",
             scene: "scene",
@@ -106,14 +107,19 @@ describe("jspsych-spatial-orientation.js plugin", () => {
             mode: "test",
             endTime: -1,
         };
+        // spy on Date.now to check timeLimit later
+        const spy = jest.spyOn(global.Date, "now");
+        // run trial
         jsPsych.init({timeline: [trial]});
         const data = jsPsych.data.getLastTrialData().values()[0];
+        // check data
         expect(data.center).toBe(trial.centerText);
         expect(data.facing).toBe(trial.topText);
         expect(data.target).toBe(trial.pointerText);
         expect(data.mode).toBe(trial.mode);
-        expect(typeof data.targetRadians).toBe("number");
-        expect(data.timeLimit).toBeLessThanOrEqual(0);
+        expect(data.targetRadians).toBe(trial.targetRadians);
+        const dateNowResult = spy.mock.results[0].value;
+        expect(data.timeLimit).toBe(trial.endTime - dateNowResult);
     });
 });
 


### PR DESCRIPTION
Hyunjoo noticed that her example data didn't contain information about the parameters for each spatial-orientation trial.

To fix this, the keys `"center"`, `"facing"`, and `"target"` (plus `"mode"`) are now recorded for each spatial-orientation trial. (The values are just copied from the trial parameters.)