### PR TITLE
format mood (percent-sum plugin) response data more sensibly

### DIFF
--- a/baseline/client/js/jspsych-percent-sum.js
+++ b/baseline/client/js/jspsych-percent-sum.js
@@ -82,12 +82,15 @@ jsPsych.plugins["percent-sum"] = (() => {
             event.preventDefault();
             // guarantee that response is valid
             if (percent_sum() === 100) {
+                // build response object using input names as keys and input values as values
+                const response = {};
+                inputs.forEach(inp => {
+                    response[inp.name] = parseInt(inp.value, 10);
+                });
+                // build data and finish trial
                 const data = {
                     preamble: trial.preamble,
-                    response: Array.from(inputs).map(inp => ({
-                        field: inp.name,
-                        value: parseInt(inp.value, 10),
-                    })),
+                    response: response,
                 };
                 jsPsych.finishTrial(data);
             } else {

--- a/baseline/client/tests/jspsych-percent-sum.test.js
+++ b/baseline/client/tests/jspsych-percent-sum.test.js
@@ -65,6 +65,35 @@ describe("jspsych-percent-sum.js plugin", () => {
         expect(button.hasAttribute("disabled")).toBe(true);  // sum should be 120
     });
 
+    it("records response data", () => {
+        // define fields and their corresponding response values
+        const fieldValuePairs = [
+            {field: "a", value: 10},
+            {field: "b", value: 20},
+            {field: "c", value: 30},
+            {field: "d", value: 40},
+        ];
+        // run trial
+        jsPsych.init({timeline: [{
+            type: "percent-sum",
+            preamble: "",
+            fields: fieldValuePairs.map(pair => pair.field),
+        }]});
+        const inputs = jsPsych.getDisplayElement().querySelectorAll("input[type=number]");
+        inputs.forEach((inp, index) => {
+            inp.value = fieldValuePairs[index].value;
+            inp.dispatchEvent(new Event("input"));
+        });
+        jsPsych.getDisplayElement().querySelector("input[type=submit]").click();
+        // check data
+        const data = jsPsych.data.getLastTrialData().values()[0];
+        expect(
+            Object.entries(data.response)
+        ).toStrictEqual(
+            fieldValuePairs.map(pair => [pair.field, pair.value])
+        );
+    });
+
     it("throws on empty fields", () => {
         const trial = {
             type: "percent-sum",


### PR DESCRIPTION
With this change, the format for percent-sum trial data in the mood-prediction and mood-memory tasks should be updated from:
```
"response": [
  {
    "field": "Good Mood",
    "value": 80
  },
  {
    "field": "Bad Mood",
    "value": 5
  },
  {
    "field": "Neutral Mood",
    "value": 15
  }
]
```
to:
```
"response": {
  "Good Mood": 80,
  "Bad Mood": 5,
  "Neutral Mood": 15
}
```
for more convenient parsing.