### PR TITLE
remove the letter "p" from verbal-fluency's possible letters

### DIFF
--- a/baseline/client/tests/verbal-fluency.test.js
+++ b/baseline/client/tests/verbal-fluency.test.js
@@ -69,4 +69,11 @@ describe("verbal-fluency", () => {
         jest.advanceTimersByTime(2000);
         expect(finished).toBe(true);  // should be finished after 61 seconds
     });
+
+    it("throws when constructed with an invalid letter", () => {
+        VerbalFluency.possibleLetters.forEach(letter => {
+            expect(() => new VerbalFluency(letter)).not.toThrow();
+        });
+        expect(() => new VerbalFluency("p")).toThrow(Error);
+    });
 });

--- a/baseline/client/verbal-fluency/verbal-fluency.js
+++ b/baseline/client/verbal-fluency/verbal-fluency.js
@@ -41,7 +41,7 @@ export class VerbalFluency {
 }
 
 VerbalFluency.taskName = "verbal-fluency";
-VerbalFluency.possibleLetters = ["s", "c", "f", "a", "d", "p"];
+VerbalFluency.possibleLetters = ["s", "c", "f", "a", "d"];
 
 VerbalFluency.instruction = {
     type: "html-keyboard-response",


### PR DESCRIPTION
Addresses #157.

Note: [Set 5 in `daily-tasks.js` already correctly excludes verbal-fluency.](https://github.com/EmotionCognitionLab/pvs/blob/673afb18102a4e63075b5921ee8ed9af485fcb3d/baseline/client/daily-tasks/daily-tasks.js#L38)