### PR TITLE
increase n-back trial targets to 5 from 4 and number of n-back n rounds to 3 from 4

### DIFF
--- a/baseline/client/n-back/n-back.js
+++ b/baseline/client/n-back/n-back.js
@@ -55,9 +55,6 @@ export class NBack {
             ...this.randTrialGroup(0),  // 2
             ...this.randTrialGroup(1),
             ...this.randTrialGroup(2),
-            ...this.randTrialGroup(0),  // 3
-            ...this.randTrialGroup(1),
-            ...this.randTrialGroup(2),
         ];
         if (this.training) {
             const training_block = [
@@ -73,11 +70,11 @@ export class NBack {
                 this.randShortPracticeLoop(2),
                 i(train_instruction_2b_html),
                 i(train_instruction_cue_0_html),
-                ...this.randTrialGroup(0, 15, 4, false),
+                ...this.randTrialGroup(0, 15, 5, false),
                 i(train_instruction_cue_1_html),
-                ...this.randTrialGroup(1, 15, 4, false),
+                ...this.randTrialGroup(1, 15, 5, false),
                 i(train_instruction_cue_2_html),
-                ...this.randTrialGroup(2, 15, 4, false),
+                ...this.randTrialGroup(2, 15, 5, false),
             ];
             return [
                 ...training_block,
@@ -125,7 +122,7 @@ export class NBack {
         };
     }
 
-    randTrialGroup(n, length = 15, targets = 4, isRelevant = true) {
+    randTrialGroup(n, length = 15, targets = 5, isRelevant = true) {
         const cue = (
             n === 0 ? this.constructor.cue0 :
             n === 1 ? this.constructor.cue1 :

--- a/baseline/client/tests/n-back.test.js
+++ b/baseline/client/tests/n-back.test.js
@@ -118,11 +118,11 @@ describe("n-back", () => {
             expect(nbTrials.every(t => t.show_duration === 800 && t.hide_duration === 1000)).toBe(true);
             // there should 2*3 n-back trials in a training block
             expect(nbTrains.length).toBe(setNum === 1 ? 2*3 : 0);
-            // there should 4*3 n-back trials in a full test block
-            expect(nbTests.length).toBe(4*3);
-            // there should be 15 digits and 4 targets per n-back test trials
+            // there should 3*3 n-back trials in a full test block
+            expect(nbTests.length).toBe(3*3);
+            // there should be 15 digits and 5 targets per n-back test trials
             expect(nbTests.every(t => t.sequence.length === 15)).toBe(true);
-            expect(nbTests.every(t => nbSequenceTargets(t.n, t.sequence) === 4)).toBe(true);
+            expect(nbTests.every(t => nbSequenceTargets(t.n, t.sequence) === 5)).toBe(true);
         });
     });
 
@@ -137,7 +137,7 @@ describe("n-back", () => {
         while (!complete) {
             completeCurrentTrial(true);
         }
-        expect(spy).toHaveBeenCalledTimes(2*3 + 4*3);
+        expect(spy).toHaveBeenCalledTimes(2*3 + 3*3);
     });
 
     it("n-back plugin trials are preceded by cues", () => {


### PR DESCRIPTION
Each n-back trial should have 5 targets (changed from 4 targets).
There should be 3 rounds of 0-backs, 1-backs, and 2-backs (changed from 4 rounds).

Addresses #156.