### PR TITLE
add attributes to prevent automatic processing on entered text for tasks

### DIFF
--- a/baseline/client/js/jspsych-memory-field.js
+++ b/baseline/client/js/jspsych-memory-field.js
@@ -20,7 +20,7 @@ jsPsych.plugins["memory-field"] = (() => {
         {
             let html = "";
             html += `<div id="jspsych-memory-field-stimulus">${trial.stimulus}</div>`;
-            html += `<input type="text" id="jspsych-memory-field-field" autocomplete="off">`;
+            html += `<input type="text" id="jspsych-memory-field-field" autocomplete="off" autocapitalize="none" autocorrect="off">`;
             html += `<div id="jspsych-memory-field-button-wrapper">`;
             html += `<input type="button" id="jspsych-memory-field-button" class="jspsych-btn" value="${trial.button_label}">`;
             html += `</div>`;

--- a/baseline/client/js/jspsych-memory-field.js
+++ b/baseline/client/js/jspsych-memory-field.js
@@ -20,7 +20,7 @@ jsPsych.plugins["memory-field"] = (() => {
         {
             let html = "";
             html += `<div id="jspsych-memory-field-stimulus">${trial.stimulus}</div>`;
-            html += `<input type="text" id="jspsych-memory-field-field" autocomplete="off" autocapitalize="none" autocorrect="off">`;
+            html += `<input type="text" id="jspsych-memory-field-field" autocomplete="off" autocapitalize="none" spellcheck="false" autocorrect="off">`;
             html += `<div id="jspsych-memory-field-button-wrapper">`;
             html += `<input type="button" id="jspsych-memory-field-button" class="jspsych-btn" value="${trial.button_label}">`;
             html += `</div>`;

--- a/baseline/client/js/jspsych-memory-field.js
+++ b/baseline/client/js/jspsych-memory-field.js
@@ -20,7 +20,7 @@ jsPsych.plugins["memory-field"] = (() => {
         {
             let html = "";
             html += `<div id="jspsych-memory-field-stimulus">${trial.stimulus}</div>`;
-            html += `<input type="text" id="jspsych-memory-field-field" autocomplete="off" autocapitalize="none" spellcheck="false" autocorrect="off">`;
+            html += `<input type="text" id="jspsych-memory-field-field" autocomplete="off" autocapitalize="none" spellcheck="false" enterkeyhint="send" autocorrect="off">`;
             html += `<div id="jspsych-memory-field-button-wrapper">`;
             html += `<input type="button" id="jspsych-memory-field-button" class="jspsych-btn" value="${trial.button_label}">`;
             html += `</div>`;

--- a/baseline/client/js/jspsych-timed-writing.js
+++ b/baseline/client/js/jspsych-timed-writing.js
@@ -33,7 +33,7 @@ jsPsych.plugins["timed-writing"] = (() => {
             let html = "";
             html += `<div id="jspsych-timed-writing-stimulus">${trial.stimulus}</div>`;
             const [r, c] = [trial.textarea_rows, trial.textarea_cols];
-            html += `<textarea id="jspsych-timed-writing-textarea" rows="${r}" cols="${c}" autocomplete="off" autocapitalize="none" spellcheck="false" autocorrect="off"></textarea>`;
+            html += `<textarea id="jspsych-timed-writing-textarea" rows="${r}" cols="${c}" autocomplete="off" autocapitalize="none" spellcheck="false" enterkeyhint="enter" autocorrect="off"></textarea>`;
             html += `<div id="jspsych-timed-writing-timer"></div>`;
             display_element.innerHTML = html;
             document.querySelector("#jspsych-timed-writing-timer").hidden = !trial.show_timer;

--- a/baseline/client/js/jspsych-timed-writing.js
+++ b/baseline/client/js/jspsych-timed-writing.js
@@ -33,7 +33,7 @@ jsPsych.plugins["timed-writing"] = (() => {
             let html = "";
             html += `<div id="jspsych-timed-writing-stimulus">${trial.stimulus}</div>`;
             const [r, c] = [trial.textarea_rows, trial.textarea_cols];
-            html += `<textarea id="jspsych-timed-writing-textarea" rows="${r}" cols="${c}" autocomplete="off" autocapitalize="none" autocorrect="off"></textarea>`;
+            html += `<textarea id="jspsych-timed-writing-textarea" rows="${r}" cols="${c}" autocomplete="off" autocapitalize="none" spellcheck="false" autocorrect="off"></textarea>`;
             html += `<div id="jspsych-timed-writing-timer"></div>`;
             display_element.innerHTML = html;
             document.querySelector("#jspsych-timed-writing-timer").hidden = !trial.show_timer;

--- a/baseline/client/js/jspsych-timed-writing.js
+++ b/baseline/client/js/jspsych-timed-writing.js
@@ -33,7 +33,7 @@ jsPsych.plugins["timed-writing"] = (() => {
             let html = "";
             html += `<div id="jspsych-timed-writing-stimulus">${trial.stimulus}</div>`;
             const [r, c] = [trial.textarea_rows, trial.textarea_cols];
-            html += `<textarea id="jspsych-timed-writing-textarea" rows="${r}" cols="${c}"></textarea>`;
+            html += `<textarea id="jspsych-timed-writing-textarea" rows="${r}" cols="${c}" autocomplete="off" autocapitalize="none" autocorrect="off"></textarea>`;
             html += `<div id="jspsych-timed-writing-timer"></div>`;
             display_element.innerHTML = html;
             document.querySelector("#jspsych-timed-writing-timer").hidden = !trial.show_timer;


### PR DESCRIPTION
Addresses #161, and also #108.

Attributes added (ordered by how important I think they are):
- [`autocomplete="off"`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute), to disable autofill.
- [`spellcheck="false"`](https://html.spec.whatwg.org/multipage/interaction.html#spelling-and-grammar-checking), to disable red squiggles.
- [`autocapitalize="none"`](https://html.spec.whatwg.org/multipage/interaction.html#autocapitalization), to disable automatic capitalization on virtual inputs.
- [`enterkeyhint`](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute), to change how the enter key looks on some virtual inputs?
- [`autocorrect="off"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocorrect), to disable autocorrect on Safari.

Additional reading:
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea