### PR TITLE
add "start-external" npm script to make the dev server accessible externally

### DIFF
--- a/baseline/client/package.json
+++ b/baseline/client/package.json
@@ -3,6 +3,7 @@
     "test": "jest",
     "test-all": "cd ../../common/logger && npm run test && cd ../../baseline/client && npm run test",
     "start": "npx webpack serve --config webpack.dev.js",
+    "start-external": "npm start -- --host 0.0.0.0",
     "build": "rm -rf dist/* && npx webpack --config webpack.prod.js",
     "predeploy": "node scripts/pre-deploy.js $npm_config_env && node scripts/version-deploy.js && npm run test-all && npm run build",
     "deploy": "node scripts/tag-deploy.js && node scripts/deploy.js"


### PR DESCRIPTION
[Passing `--host 0.0.0.0` to `webpack serve` instructs the development server to listen on all available IP addresses.](https://webpack.js.org/configuration/dev-server/#devserverhost) This is useful when manually testing the server using multiple different machines on the local network.