### PR TITLE
omit rest for final n-back trial

### DIFF
--- a/baseline/client/n-back/n-back.js
+++ b/baseline/client/n-back/n-back.js
@@ -57,7 +57,7 @@ export class NBack {
             ...this.randTrialGroup(2),
             ...this.randTrialGroup(0),  // 2
             ...this.randTrialGroup(1),
-            ...this.randTrialGroup(2),
+            ...this.randTrialGroup(2, undefined, undefined, undefined, false)
         ];
         if (this.training) {
             const training_block = [
@@ -125,7 +125,7 @@ export class NBack {
         };
     }
 
-    randTrialGroup(n, length = 15, targets = 5, isRelevant = true) {
+    randTrialGroup(n, length = 15, targets = 5, isRelevant = true, hasRest = true) {
         const cue = (
             n === 0 ? this.constructor.cue0 :
             n === 1 ? this.constructor.cue1 :
@@ -136,8 +136,7 @@ export class NBack {
             throw new Error("cue not implemented for n");
         }
         const trial = this.randTrial(n, length, targets, isRelevant);
-        const rest = this.constructor.rest;
-        return [cue, trial, rest];
+        return hasRest ? [cue, trial, this.constructor.rest] : [cue, trial];
     }
 
     randTrial(n, length, targets, isRelevant) {

--- a/baseline/client/n-back/n-back.js
+++ b/baseline/client/n-back/n-back.js
@@ -73,11 +73,11 @@ export class NBack {
                 this.randShortPracticeLoop(2),
                 i(train_instruction_2b_html),
                 i(train_instruction_cue_0_html),
-                ...this.randTrialGroup(0, 15, 5, false),
+                ...this.randTrialGroup(0, undefined, undefined, false),
                 i(train_instruction_cue_1_html),
-                ...this.randTrialGroup(1, 15, 5, false),
+                ...this.randTrialGroup(1, undefined, undefined, false),
                 i(train_instruction_cue_2_html),
-                ...this.randTrialGroup(2, 15, 5, false),
+                ...this.randTrialGroup(2, undefined, undefined, false),
             ];
             return [
                 ...training_block,

--- a/baseline/client/tests/n-back.test.js
+++ b/baseline/client/tests/n-back.test.js
@@ -240,7 +240,7 @@ describe("n-back", () => {
     });
 
     it("n-back plugin trials are succeeded by rests", () => {
-        const flatTimeline = (new NBack(1)).getTimeline();
+        const flatTimeline = flattenTimeline((new NBack(1)).getTimeline());
         const lastNBackTrialIndex = (() => {
             for (let i = flatTimeline.length - 1; i >= 0; --i) {
                 if (flatTimeline[i].type === "n-back") {
@@ -253,7 +253,7 @@ describe("n-back", () => {
         expect(
             flatTimeline.every((trial, index) => {
                 if (trial.type === "n-back" && index !== lastNBackTrialIndex) {
-                    return flatTimeline[index + 1] === NBack.rest;
+                    return flatTimeline[index + 1] === NBack.rest.timeline[0];
                 } else {
                     return true;
                 }

--- a/baseline/client/tests/n-back.test.js
+++ b/baseline/client/tests/n-back.test.js
@@ -241,9 +241,18 @@ describe("n-back", () => {
 
     it("n-back plugin trials are succeeded by rests", () => {
         const flatTimeline = (new NBack(1)).getTimeline();
+        const lastNBackTrialIndex = (() => {
+            for (let i = flatTimeline.length - 1; i >= 0; --i) {
+                if (flatTimeline[i].type === "n-back") {
+                    return i;
+                }
+            }
+            return null;
+        })();
+        expect(lastNBackTrialIndex).not.toBe(null);
         expect(
             flatTimeline.every((trial, index) => {
-                if (trial.type === "n-back") {
+                if (trial.type === "n-back" && index !== lastNBackTrialIndex) {
                     return flatTimeline[index + 1] === NBack.rest;
                 } else {
                     return true;

--- a/baseline/client/tests/n-back.test.js
+++ b/baseline/client/tests/n-back.test.js
@@ -219,13 +219,19 @@ describe("n-back", () => {
         expect(
             flatTimeline.every((trial, index) => {
                 if (trial.type === "n-back") {
-                    const expected_cue = (
-                        trial.n === 0 ? NBack.cue0 :
-                        trial.n === 1 ? NBack.cue1 :
-                        trial.n === 2 ? NBack.cue2 :
-                        null
-                    );
-                    return expected_cue !== null && flatTimeline[index - 1] === expected_cue;
+                    const cueStimulus = flatTimeline[index - 2].stimulus;
+                    const cueWrongStimulus = flatTimeline[index - 1].stimulus;
+                    if (trial.n === 0) {
+                        return cueStimulus === cue_0_html && cueWrongStimulus === cue_0_wrong_html;
+                    } else if (trial.n === 1) {
+                        return cueStimulus === cue_1_html && cueWrongStimulus === cue_1_wrong_html;
+                    } else if (trial.n === 2) {
+                        return cueStimulus === cue_2_html && cueWrongStimulus === cue_2_wrong_html;
+                    } else {
+                        fail("invalid n");
+                        return false;
+                    }
+                    return expected_cue !== null && flatTimeline[index - 2] === expected_cue;
                 } else {
                     return true;
                 }

--- a/baseline/client/tests/n-back.test.js
+++ b/baseline/client/tests/n-back.test.js
@@ -1,5 +1,5 @@
 import { NBack } from "../n-back/n-back.js";
-import { pressKey, cartesianProduct } from "./utils.js";
+import { pressKey, cartesianProduct, flattenTimeline } from "./utils.js";
 import cue_0_html from "../n-back/frag/cue_0.html";
 import cue_1_html from "../n-back/frag/cue_1.html";
 import cue_2_html from "../n-back/frag/cue_2.html";
@@ -215,9 +215,9 @@ describe("n-back", () => {
     });
 
     it("n-back plugin trials are preceded by cues", () => {
-        const timeline = (new NBack(1)).getTimeline();
+        const flatTimeline = flattenTimeline((new NBack(1)).getTimeline());
         expect(
-            timeline.every((trial, index) => {
+            flatTimeline.every((trial, index) => {
                 if (trial.type === "n-back") {
                     const expected_cue = (
                         trial.n === 0 ? NBack.cue0 :
@@ -225,7 +225,7 @@ describe("n-back", () => {
                         trial.n === 2 ? NBack.cue2 :
                         null
                     );
-                    return expected_cue !== null && timeline[index - 1] === expected_cue;
+                    return expected_cue !== null && flatTimeline[index - 1] === expected_cue;
                 } else {
                     return true;
                 }
@@ -234,11 +234,11 @@ describe("n-back", () => {
     });
 
     it("n-back plugin trials are succeeded by rests", () => {
-        const timeline = (new NBack(1)).getTimeline();
+        const flatTimeline = (new NBack(1)).getTimeline();
         expect(
-            timeline.every((trial, index) => {
+            flatTimeline.every((trial, index) => {
                 if (trial.type === "n-back") {
-                    return timeline[index + 1] === NBack.rest;
+                    return flatTimeline[index + 1] === NBack.rest;
                 } else {
                     return true;
                 }

--- a/baseline/client/tests/utils.js
+++ b/baseline/client/tests/utils.js
@@ -31,3 +31,7 @@ export const clickIcirc = (icirc, x, y) => {
         clientY: -y + icirc.height/2 + rect.top,
     }));
 };
+
+export function flattenTimeline(timeline) {
+    return timeline.flatMap(node => node.timeline ? flattenTimeline(node.timeline) : node);
+}


### PR DESCRIPTION
Addresses #115.

Also improves the existing tests for cues and rests by first flattening the n-back task timeline. (Prior to this change, n-back trial blocks in subtimelines would not have been checked.)

Also explicitly passes `undefined` to `NBack.randTrialGroup` when the default parameter is wanted. (Prevents mistakes in the future when default is changed but the passed value is not.)