### PR TITLE
fix pvs-breath-pacer dependency URL

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "better-sqlite3": "^7.5.1",
     "core-js": "^3.6.5",
     "node-fetch": "2",
-    "pvs-breath-pacer": "https://github.com/EmotionCognitionLab/pvs-breath-pacer.git",
+    "pvs-breath-pacer": "git+https://github.com/EmotionCognitionLab/pvs-breath-pacer.git",
     "vue": "^3.0.0",
     "vue-router": "4"
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10243,9 +10243,9 @@ pupa@^2.1.1:
   dependencies:
     escape-goat "^2.0.0"
 
-"pvs-breath-pacer@https://github.com/EmotionCognitionLab/pvs-breath-pacer.git":
+"pvs-breath-pacer@git+https://github.com/EmotionCognitionLab/pvs-breath-pacer.git":
   version "0.4.0"
-  resolved "git+ssh://git@github.com/EmotionCognitionLab/pvs-breath-pacer.git#755b6f88d2c7a22927dd347c75e38042e6838eb9"
+  resolved "git+https://github.com/EmotionCognitionLab/pvs-breath-pacer.git#755b6f88d2c7a22927dd347c75e38042e6838eb9"
   optionalDependencies:
     css-loader "^6.5.1"
     html-webpack-plugin "^5.5.0"


### PR DESCRIPTION
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#git-urls-as-dependencies
> `<protocol>` is one of `git`, `git+ssh`, `git+http`, `git+https`, or `git+file`.

I think `yarn install` interpreted the current (incorrect) `https:` as `git+ssh:` instead of `git+https:`, preventing me from cloning the repository.

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#urls-as-dependencies seems to imply that `https:` should've been treated as a tarball instead, so I'm not really sure what's going on there.