### PR TITLE
show errors in admin/download

### DIFF
--- a/baseline/client/admin/download/download.js
+++ b/baseline/client/admin/download/download.js
@@ -3,39 +3,47 @@ import "./style.css";
 import { getAuth } from "auth/auth.js";
 import ApiClient from "../../../../common/api/client.js";
 
+const errorDiv = document.getElementById("error");
 const experimentSelect = document.getElementById("experiment-select");
 const experimentButton = document.getElementById("experiment-button");
-const experimentDownload = document.getElementById("experiment-download");
+const downloadStatus = document.getElementById("download-status");
+
+function handleError(err) {
+    errorDiv.textContent = `error: ${err.message ?? err}`;
+    console.error("error:", err);
+}
 
 function initializeButton(apiClient) {
     experimentButton.addEventListener("click", async () => {
         startDownload();
-        const results = await apiClient.getResultsForExperiment(experimentSelect.value);
-        endDownload();
-        if (results.url) {
-            window.location.href = results.url;
-        } else if (results.empty) {
-            alert(`There were no results for the "${experimentSelect.value}" experiment.`);
+        try {
+            const results = await apiClient.getResultsForExperiment(experimentSelect.value);
+            if (results.url) {
+                window.location.href = results.url;
+            } else if (results.empty) {
+                alert(`There were no results for the "${experimentSelect.value}" experiment.`);
+            }
+        } catch (err) {
+            handleError(err);
         }
+        endDownload();
     });
 }
 
 function endDownload() {
     experimentButton.removeAttribute("disabled");
-    experimentDownload.textContent = "";
+    downloadStatus.textContent = "";
 }
 
 function startDownload() {
     experimentButton.setAttribute("disabled", true);
-    experimentDownload.textContent = "Querying...";
+    downloadStatus.textContent = "Querying...";
 }
 
 const auth = getAuth(
     session => {
         initializeButton(new ApiClient(session));
     },
-    err => {
-        console.error("error:", err);
-    }
+    handleError,
 );
 auth.getSession();

--- a/baseline/client/admin/download/index.ejs
+++ b/baseline/client/admin/download/index.ejs
@@ -5,6 +5,7 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
 </head>
 <body>
+    <div id="error"></div>
     <label for="experiment-select">Select an experiment:</label>
     <select id="experiment-select">
         <option value="" selected disabled>--experiment name--</option>
@@ -29,6 +30,6 @@
         <option value="verbal-learning-recall">verbal-learning-recall</option>
     </select>
     <button id="experiment-button" type="button">Query</button>
-    <p id="experiment-download"></a>
+    <p id="download-status"></a>
 </body>
 </html>

--- a/baseline/client/admin/download/style.css
+++ b/baseline/client/admin/download/style.css
@@ -1,4 +1,4 @@
-#experiment-download[aria-disabled="true"] {
-    pointer-events: none;
-    text-decoration: none;
+#error {
+    color: red;
+    margin-bottom: 10px;
 }


### PR DESCRIPTION
Adds an error `div` to the download page and a catch so that if the `await apiClient.getResultsForExperiment(experimentSelect.value)` throws the user can know about it.